### PR TITLE
Maven Central publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,8 @@ jobs:
           files: jvm/library/build/reports/jacoco/test/jacocoTestReport.xml
   jvm-publish:
     name: 🚀 Publish JVM library
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -428,6 +430,12 @@ jobs:
         with:
           name: jvm-html-docs-jar
           path: ~/.m2/repository/io/tira/tirex-tracker/*/tirex-tracker-*-html-docs.jar
+      - name: 🚀 Publish JVM library to GitHub Packages
+        if: matrix.java == '21'
+        env:
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: jvm/gradlew --project-dir jvm/ publishAllPublicationsToGitHubPackagesRepository
       - name: 🚀 Publish JVM library to Maven Central
         if: matrix.java == '21'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: jvm/library/build/reports/jacoco/test/jacocoTestReport.xml
   jvm-publish:
-    name: 🚀 Publish JVM library to GitHub Packages
+    name: 🚀 Publish JVM library
     strategy:
       fail-fast: false
       matrix:
@@ -428,12 +428,15 @@ jobs:
         with:
           name: jvm-html-docs-jar
           path: ~/.m2/repository/io/tira/tirex-tracker/*/tirex-tracker-*-html-docs.jar
-      - name: 🚀 Publish JVM library to GitHub Packages
+      - name: 🚀 Publish JVM library to Maven Central
         if: matrix.java == '21'
         env:
-          USERNAME: ${{ github.actor }}
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: jvm/gradlew --project-dir jvm/ publishAllPublicationsToGitHubPackagesRepository
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVENCENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVENCENTRAL_PASSWORD }}
+        run: jvm/gradlew --project-dir jvm/ jreleaserDeploy
   python-build:
     name: 🏗️ Build Python wheels
     strategy:
@@ -689,7 +692,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
   python-publish:
-    name: 🚀 Publish Python wheels to PyPI
+    name: 🚀 Publish Python wheels
     if: github.event_name == 'push' && endsWith(github.event.base_ref, 'master') && startsWith(github.ref, 'refs/tags')
     needs:
       - c-build-library

--- a/jvm/.gitignore
+++ b/jvm/.gitignore
@@ -5,3 +5,5 @@
 build
 
 *.iml
+
+jreleaser.yml

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     id("com.palantir.git-version") version "3.1.0" apply false
     id("com.github.gmazzo.buildconfig") version "5.5.1" apply false
     id("org.jetbrains.dokka") version "2.0.0" apply false
+    id("org.jreleaser") version "1.17.0" apply false
 }

--- a/jvm/library/build.gradle.kts
+++ b/jvm/library/build.gradle.kts
@@ -17,6 +17,9 @@ plugins {
 
 val gitVersion: Closure<String> by extra
 
+group = "io.tira"
+version = gitVersion()
+
 repositories {
     mavenCentral()
 }
@@ -121,9 +124,9 @@ publishing {
 
     publications {
         withType<MavenPublication> {
-            groupId = "io.tira"
+            groupId = project.group.toString()
             artifactId = "tirex-tracker"
-            version = gitVersion()
+            version = project.version.toString()
 
             from(components["java"])
 
@@ -162,44 +165,17 @@ publishing {
             }
         }
 
-        register<MavenPublication>("library")
+        register<MavenPublication>("maven")
+    }
+
+    repositories {
+        maven {
+            url = layout.buildDirectory.dir("staging-deploy").get().asFile.toURI()
+        }
     }
 }
 
 jreleaser {
-    project {
-        name = "tirex-tracker"
-        description = "Automatic resource and metadata tracking for information retrieval experiments."
-        version = gitVersion()
-        author("Jan Heinrich Merker")
-        author("Tim Hagen")
-        author("Maik Fröbe")
-        license = "MIT License"
-        links {
-            homepage = "https://github.com/tira-io/tirex-tracker"
-            bugTracker = "https://github.com/tira-io/tirex-tracker/issues"
-            contact = "https://webis.de"
-            license = "https://opensource.org/license/MIT"
-        }
-        inceptionYear = "2025"
-    }
-
-    release {
-        github {
-            repoOwner = "tira-io"
-            overwrite = true
-        }
-    }
-
-    distributions {
-        register("app") {
-            artifact {
-                // TODO
-                // setPath("build/distributions/{{distributionName}}-{{projectVersion}}.zip")
-            }
-        }
-    }
-
     signing {
         active.set(Active.ALWAYS)
         armored = true

--- a/jvm/library/build.gradle.kts
+++ b/jvm/library/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id("com.palantir.git-version")
     id("com.github.gmazzo.buildconfig")
     id("org.jetbrains.dokka")
+    id("org.jreleaser")
 }
 
 val gitVersion: Closure<String> by extra
@@ -103,6 +104,41 @@ buildConfig {
     className("Build")   // forces the class name. Defaults to 'BuildConfig'
     packageName("io.tira.tirex.tracker")  // forces the package. Defaults to '${project.group}'
     buildConfigField("VERSION", provider(gitVersion))
+}
+
+jreleaser {
+    project {
+        name = "tirex-tracker"
+        description = "Automatic resource and metadata tracking for information retrieval experiments."
+        version = gitVersion()
+        author("Jan Heinrich Merker")
+        author("Tim Hagen")
+        author("Maik Fröbe")
+        license = "MIT License"
+        links {
+            homepage = "https://github.com/tira-io/tirex-tracker"
+            bugTracker = "https://github.com/tira-io/tirex-tracker/issues"
+            contact = "https://webis.de"
+            license = "https://opensource.org/license/MIT"
+        }
+        inceptionYear = "2025"
+    }
+
+    release {
+        github {
+            repoOwner = "tira-io"
+            overwrite = true
+        }
+    }
+
+    distributions {
+        register("app") {
+            artifact {
+                // TODO
+                // setPath("build/distributions/{{distributionName}}-{{projectVersion}}.zip")
+            }
+        }
+    }
 }
 
 publishing {

--- a/jvm/library/build.gradle.kts
+++ b/jvm/library/build.gradle.kts
@@ -119,8 +119,8 @@ publishing {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/tira-io/tirex-tracker")
             credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-                password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
+                username = System.getenv("GITHUB_USERNAME")
+                password = System.getenv("GITHUB_PASSWORD")
             }
         }
 

--- a/jvm/library/build.gradle.kts
+++ b/jvm/library/build.gradle.kts
@@ -1,6 +1,7 @@
 import groovy.lang.Closure
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jreleaser.model.Active
 
 plugins {
     `java-library`
@@ -106,41 +107,6 @@ buildConfig {
     buildConfigField("VERSION", provider(gitVersion))
 }
 
-jreleaser {
-    project {
-        name = "tirex-tracker"
-        description = "Automatic resource and metadata tracking for information retrieval experiments."
-        version = gitVersion()
-        author("Jan Heinrich Merker")
-        author("Tim Hagen")
-        author("Maik Fröbe")
-        license = "MIT License"
-        links {
-            homepage = "https://github.com/tira-io/tirex-tracker"
-            bugTracker = "https://github.com/tira-io/tirex-tracker/issues"
-            contact = "https://webis.de"
-            license = "https://opensource.org/license/MIT"
-        }
-        inceptionYear = "2025"
-    }
-
-    release {
-        github {
-            repoOwner = "tira-io"
-            overwrite = true
-        }
-    }
-
-    distributions {
-        register("app") {
-            artifact {
-                // TODO
-                // setPath("build/distributions/{{distributionName}}-{{projectVersion}}.zip")
-            }
-        }
-    }
-}
-
 publishing {
     repositories {
         maven {
@@ -197,5 +163,57 @@ publishing {
         }
 
         register<MavenPublication>("library")
+    }
+}
+
+jreleaser {
+    project {
+        name = "tirex-tracker"
+        description = "Automatic resource and metadata tracking for information retrieval experiments."
+        version = gitVersion()
+        author("Jan Heinrich Merker")
+        author("Tim Hagen")
+        author("Maik Fröbe")
+        license = "MIT License"
+        links {
+            homepage = "https://github.com/tira-io/tirex-tracker"
+            bugTracker = "https://github.com/tira-io/tirex-tracker/issues"
+            contact = "https://webis.de"
+            license = "https://opensource.org/license/MIT"
+        }
+        inceptionYear = "2025"
+    }
+
+    release {
+        github {
+            repoOwner = "tira-io"
+            overwrite = true
+        }
+    }
+
+    distributions {
+        register("app") {
+            artifact {
+                // TODO
+                // setPath("build/distributions/{{distributionName}}-{{projectVersion}}.zip")
+            }
+        }
+    }
+
+    signing {
+        active.set(Active.ALWAYS)
+        armored = true
+    }
+
+    deploy {
+        maven {
+            mavenCentral {
+                register("sonatype") {
+                    active.set(Active.ALWAYS)
+                    url.set("https://central.sonatype.com/api/v1/publisher")
+                    stagingRepository("target/staging-deploy")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds the necessary configuration to publish the Java package on the [Maven Central Repository](https://central.sonatype.com/artifact/io.tira/tirex-tracker).
This simplifies using the library as most dependency management tools (e.g. Gradle) come with Maven Central enabled per default. So users only need to add the `implementation("io.tira:tirex-tracker")` line to their Gradle config and do no longer need to configure the GitHub Packages repository.

Fixes #24 