### PR TITLE
`-o` and `-f"irmetadata"`

### DIFF
--- a/c/examples/03_measure_command/CMakeLists.txt
+++ b/c/examples/03_measure_command/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(measure
 )
 
 target_compile_features(measure PUBLIC cxx_std_20)
-target_link_libraries(measure tirex_tracker_static)
+target_link_libraries(measure tirex_tracker_full_static)
 
 option(TIREX_TRACKER_BUILD_CMD_DEB "Build the debian package for the measure command" OFF)
 

--- a/c/examples/03_measure_command/config.hpp
+++ b/c/examples/03_measure_command/config.hpp
@@ -8,6 +8,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -39,11 +40,13 @@ namespace tirex {
 		std::vector<std::string> statproviders;
 		size_t pollIntervalMs;
 		bool pedantic;
+		std::optional<std::string> outfile;
 
 		const ResultFormatter& getFormatter() const {
 			static const std::map<std::string, ResultFormatter> formatters{
 					{"simple", simpleFormatter},
 					{"json", jsonFormatter},
+					{"irmetadata", irmetadataFormatter},
 			};
 			return formatters.at(formatter);
 		}

--- a/c/examples/03_measure_command/formatters.cpp
+++ b/c/examples/03_measure_command/formatters.cpp
@@ -50,19 +50,35 @@ static const char* measureToName[] = {
 };
 
 /* SIMPLE FORMATTER */
-void tirex::simpleFormatter(std::ostream& stream, const tirexResult* result) noexcept {
+void tirex::simpleFormatter(std::ostream& stream, const tirexResult* info, const tirexResult* result) noexcept {
+	// Info
 	size_t num;
 	tirexResultEntry entry;
-	auto err = tirexResultEntryNum(result, &num);
+	auto err = tirexResultEntryNum(info, &num);
 	assert(err == TIREX_SUCCESS);
 	for (size_t i = 0; i < num; ++i) {
-		auto err = tirexResultEntryGetByIndex(result, i, &entry);
+		err = tirexResultEntryGetByIndex(info, i, &entry);
+		assert(err == TIREX_SUCCESS);
+		stream << '[' << measureToName[entry.source] << "] " << reinterpret_cast<const char*>(entry.value) << std::endl;
+	}
+	// Result
+	err = tirexResultEntryNum(result, &num);
+	assert(err == TIREX_SUCCESS);
+	for (size_t i = 0; i < num; ++i) {
+		err = tirexResultEntryGetByIndex(result, i, &entry);
 		assert(err == TIREX_SUCCESS);
 		stream << '[' << measureToName[entry.source] << "] " << reinterpret_cast<const char*>(entry.value) << std::endl;
 	}
 }
 
 /* JSON FORMATTER */
-void tirex::jsonFormatter(std::ostream& stream, const tirexResult* result) noexcept {
-	return tirex::simpleFormatter(stream, result); /** \todo implement properly **/
+void tirex::jsonFormatter(std::ostream& stream, const tirexResult* info, const tirexResult* result) noexcept {
+	tirex::simpleFormatter(stream, info, result); /** \todo implement properly **/
+}
+
+/** IR_METADATA FORMATTER */
+extern tirexError writeIrMetadata(const tirexResult* info, const tirexResult* result, std::ostream& stream);
+
+void tirex::irmetadataFormatter(std::ostream& stream, const tirexResult* info, const tirexResult* result) noexcept {
+	writeIrMetadata(result, nullptr, stream);
 }

--- a/c/examples/03_measure_command/formatters.hpp
+++ b/c/examples/03_measure_command/formatters.hpp
@@ -7,10 +7,12 @@
 #include <ostream>
 
 namespace tirex {
-	using ResultFormatter = std::function<void(std::ostream& stream, const tirexResult* result)>;
+	using ResultFormatter =
+			std::function<void(std::ostream& stream, const tirexResult* info, const tirexResult* result)>;
 
-	extern void simpleFormatter(std::ostream& stream, const tirexResult* result) noexcept;
-	extern void jsonFormatter(std::ostream& stream, const tirexResult* result) noexcept;
+	extern void simpleFormatter(std::ostream& stream, const tirexResult* info, const tirexResult* result) noexcept;
+	extern void jsonFormatter(std::ostream& stream, const tirexResult* info, const tirexResult* result) noexcept;
+	extern void irmetadataFormatter(std::ostream& stream, const tirexResult* info, const tirexResult* result) noexcept;
 } // namespace tirex
 
 #endif

--- a/c/extensions/CMakeLists.txt
+++ b/c/extensions/CMakeLists.txt
@@ -14,3 +14,13 @@ target_include_directories(tirex_tracker_full PUBLIC ${CMAKE_CURRENT_LIST_DIR} $
 # target_link_libraries(tirex_tracker_full PRIVATE "-Wl,--whole-archive" tirex_tracker_static "-Wl,--no-whole-archive")
 target_link_libraries(tirex_tracker_full PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,tirex_tracker_static>")
 target_compile_definitions(tirex_tracker_full PRIVATE TIREX_TRACKER_LIB_EXPORT)
+
+add_library(tirex_tracker_full_static STATIC
+    irtracker.cpp
+)
+target_include_directories(tirex_tracker_full_static PUBLIC ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_LIST_DIR}/../include)
+# For now see if the LINK_LIBRARY generator works with old systems (requires 3.24). If it is too new, uncomment the
+# following line:
+# target_link_libraries(tirex_tracker_full_static PRIVATE "-Wl,--whole-archive" tirex_tracker_static "-Wl,--no-whole-archive")
+target_link_libraries(tirex_tracker_full_static PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,tirex_tracker_static>")
+target_compile_definitions(tirex_tracker_full_static PRIVATE TIREX_TRACKER_LIB_EXPORT)

--- a/c/extensions/irtracker.cpp
+++ b/c/extensions/irtracker.cpp
@@ -226,15 +226,15 @@ static void writeResources(const ResultMap& results, std::ostream& stream) {
 		stream << "    used system: " << it->second << '\n';
 }
 
-tirexError tirexResultExportIrMetadata(const tirexResult* info, const tirexResult* result, const char* filepath) {
+// Not static because internally the measurecommand calls this. Not pretty :(
+tirexError writeIrMetadata(const tirexResult* info, const tirexResult* result, std::ostream& stream) {
 	std::string version = "0.2";
 	ResultMap map;
-	asMap(map, info, versionFilter(version));
-	asMap(map, result, versionFilter(version));
+	if (info != nullptr)
+		asMap(map, info, versionFilter(version));
+	if (result != nullptr)
+		asMap(map, result, versionFilter(version));
 
-	std::ofstream stream(filepath);
-	if (!stream)
-		return tirexError::TIREX_INVALID_ARGUMENT;
 	stream << "ir_metadata.start\n";
 	stream << "schema version: " << version << '\n';
 	writePlatform(map, stream);
@@ -242,4 +242,11 @@ tirexError tirexResultExportIrMetadata(const tirexResult* info, const tirexResul
 	writeResources(map, stream);
 	stream << "ir_metadata.end\n";
 	return tirexError::TIREX_SUCCESS;
+}
+
+tirexError tirexResultExportIrMetadata(const tirexResult* info, const tirexResult* result, const char* filepath) {
+	std::ofstream stream(filepath);
+	if (!stream)
+		return tirexError::TIREX_INVALID_ARGUMENT;
+	return writeIrMetadata(info, result, stream);
 }


### PR DESCRIPTION
This PR introduces the `-o <filename>` option and `irmetadata` formatter (used via `-f irmetadata`) to the measure command.