### PR TITLE
Auto-guess export format and improve ir_metadata handling

### DIFF
--- a/c/extensions/irtracker.cpp
+++ b/c/extensions/irtracker.cpp
@@ -235,12 +235,10 @@ tirexError writeIrMetadata(const tirexResult* info, const tirexResult* result, s
 	if (result != nullptr)
 		asMap(map, result, versionFilter(version));
 
-	stream << "ir_metadata.start\n";
 	stream << "schema version: " << version << '\n';
 	writePlatform(map, stream);
 	writeImplementation(map, stream);
 	writeResources(map, stream);
-	stream << "ir_metadata.end\n";
 	return tirexError::TIREX_SUCCESS;
 }
 

--- a/jvm/library/src/main/kotlin/io/tira/tirex/tracker/Tracker.kt
+++ b/jvm/library/src/main/kotlin/io/tira/tirex/tracker/Tracker.kt
@@ -720,16 +720,14 @@ class TrackingHandle private constructor(
                 defaultFlowStyle = DumperOptions.FlowStyle.AUTO
             },
         )
-        val irMetadataString = exportFilePath.useLines { lines ->
-            lines.dropWhile {
-                it != "ir_metadata.start"
-            }.drop(1).takeWhile {
-                it != "ir_metadata.end"
-            }.joinToString("\n")
-            // FIXME: There's a bug in the YAML output format that we work around here:
-        }.replace(Regex("""caches: (.*),"""), """caches: {\1}""")
-        val irMetadata: MutableMap<String, Any?> = yaml.load<MutableMap<String, Any?>>(irMetadataString)
-
+        val irMetadataYamlString = exportFilePath.readText()
+            .removePrefix("ir_metadata.start\n") // Remove optional ir_metadata prefix line.
+            .removeSuffix("ir_metadata.end\n") // Remove optional ir_metadata suffix line.
+            .replace(
+                Regex("""caches: (.*),"""),
+                """caches: {\1}"""
+            ) // FIXME: There's a bug in the YAML output format (https://github.com/tira-io/tirex-tracker/issues/42) that we work around here.
+        val irMetadata: MutableMap<String, Any?> = yaml.load<MutableMap<String, Any?>>(irMetadataYamlString)
 
         // Add user-provided metadata.
         val method: MutableMap<String, Any?> =

--- a/jvm/library/src/main/kotlin/io/tira/tirex/tracker/Tracker.kt
+++ b/jvm/library/src/main/kotlin/io/tira/tirex/tracker/Tracker.kt
@@ -671,9 +671,29 @@ class TrackingHandle private constructor(
     private fun export(result: Pointer) {
         if (exportFilePath == null) return
         when (exportFormat) {
-            null -> return
+            null -> exportGuessedFormat(result)
             ExportFormat.IR_METADATA -> exportIrMetadata(result)
         }
+    }
+
+    private fun exportGuessedFormat(result: Pointer) {
+        if (exportFilePath == null) return
+        else if (
+            listOf(
+                ".ir_metadata",
+                ".ir-metadata",
+                ".ir_metadata.yml",
+                ".ir-metadata.yml",
+                ".ir_metadata.yaml",
+                ".ir-metadata.yaml",
+                ".ir_metadata.gz",
+                ".ir-metadata.gz",
+                ".ir_metadata.yml.gz",
+                ".ir-metadata.yml.gz",
+                ".ir_metadata.yaml.gz",
+                ".ir-metadata.yaml.gz",
+            ).any { exportFilePath.name.endsWith(it) }
+        ) exportIrMetadata(result)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/python/tirex_tracker/__init__.py
+++ b/python/tirex_tracker/__init__.py
@@ -894,7 +894,7 @@ class TrackingHandle(ContextManager["TrackingHandle"], Mapping[Measure, ResultEn
         if buffer.endswith(b"ir_metadata.end\n"):
             buffer = buffer[: -len(b"ir_metadata.end\n")]
 
-        # FIXME: There's a bug in the YAML output format that we work around here:
+        # FIXME: There's a bug in the YAML output format (https://github.com/tira-io/tirex-tracker/issues/42) that we work around here:
         from re import sub
 
         buffer = sub(rb"caches: (.*),", rb"caches: {\1}", buffer)

--- a/python/tirex_tracker/__init__.py
+++ b/python/tirex_tracker/__init__.py
@@ -842,11 +842,33 @@ class TrackingHandle(ContextManager["TrackingHandle"], Mapping[Measure, ResultEn
         if self._export_file_path is None:
             return
         elif self._export_format is None:
-            return
+            self._export_guessed_format(result)
         elif self._export_format == ExportFormat.IR_METADATA:
             self._export_ir_metadata(result)
         else:
             raise ValueError("Invalid export format.")
+
+    def _export_guessed_format(self, result: "Pointer[_Result]") -> None:
+        if self._export_file_path is None:
+            return
+        elif any(
+            Path(self._export_file_path).name.endswith(extension)
+            for extension in [
+                ".ir_metadata",
+                ".ir-metadata",
+                ".ir_metadata.yml",
+                ".ir-metadata.yml",
+                ".ir_metadata.yaml",
+                ".ir-metadata.yaml",
+                ".ir_metadata.gz",
+                ".ir-metadata.gz",
+                ".ir_metadata.yml.gz",
+                ".ir-metadata.yml.gz",
+                ".ir_metadata.yaml.gz",
+                ".ir-metadata.yaml.gz",
+            ]
+        ):
+            self._export_ir_metadata(result)
 
     def _export_ir_metadata(self, result: "Pointer[_Result]") -> None:
         if self._export_file_path is None:


### PR DESCRIPTION
This PR enables users not to specify the export format explicitly. The appropriate export format is then guessed based on the file extension. It also improves the handling of the `ir_metadata` YAML that is exported from C code.