### PR TITLE
Ship binary with python code

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -59,6 +59,9 @@ exclude = ["build", "venv"]
     "*.so",
     "*.dll",
     "*.dylib",
+    "measure-*-linux",
+    "measure-*-macos",
+    "measure-*-windows.exe",
 ]
 
 [tool.setuptools_scm]

--- a/python/test/test_tirex_tracker.py
+++ b/python/test/test_tirex_tracker.py
@@ -4,6 +4,7 @@ from time import sleep
 from typing import Collection, Mapping
 
 from tirex_tracker import (
+    _find_executable,
     provider_infos,
     measure_infos,
     fetch_info,
@@ -31,6 +32,12 @@ def test_provider_infos() -> None:
     assert isinstance(actual, Collection)
     assert len(actual) > 0
 
+
+def test_find_executable() -> None:
+    actual = _find_executable()
+
+    assert actual is not None
+    assert Path(actual).exists()
 
 def test_measure_infos() -> None:
     actual = measure_infos()

--- a/python/tirex_tracker/__init__.py
+++ b/python/tirex_tracker/__init__.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from sys import modules as sys_modules, executable, argv, platform, version_info
 from tempfile import mkdtemp
 from traceback import extract_stack
+from glob import glob
 from typing import (
     ItemsView,
     Iterator,
@@ -599,6 +600,24 @@ def _find_library() -> Path:
     else:
         raise RuntimeError("Unsupported platform.")
     return files(__name__) / path
+
+
+def _find_executable() -> Path:
+    path: str
+    if platform == "linux":
+        path = "measure-*-linux"
+    elif platform == "darwin":
+        path = "measure-*-macos"
+    elif platform == "win32":
+        path = "measure-*-windows.exe"
+    else:
+        raise RuntimeError("Unsupported platform.")
+
+    search_path = files(__name__) / path
+    ret = glob(str(search_path))
+    if len(ret) != 1:
+        raise RuntimeError(f'Could not find binary in {search_path}. Got: {ret}')
+    return ret[0]
 
 
 def _load_library() -> _TirexTrackerLibrary:


### PR DESCRIPTION
I would need that pip3 install also directly ships the executable binary and makes it accessible, this would be the goal of this pull request.