### PR TITLE
fix python source

### DIFF
--- a/python/test/test_integration.py
+++ b/python/test/test_integration.py
@@ -58,7 +58,7 @@ def test_python_script() -> None:
         assert "script path" in yaml_content["implementation"]["source"]["archive"]
         assert "example.py" in yaml_content["implementation"]["source"]["archive"]["script path"]
 
-        archive_path = Path(yaml_content["implementation"]["source"]["archive"]["path"])
+        archive_path = Path(working_dir_path) / Path(yaml_content["implementation"]["source"]["archive"]["path"])
         assert archive_path.exists()
 
         with ZipFile(archive_path) as zip_file:
@@ -102,12 +102,6 @@ def test_jupyter_notebook() -> None:
             yaml_content = yaml.load(yaml_file)
 
         assert "implementation" in yaml_content
-        assert "script" in yaml_content["implementation"]
-        assert "path" in yaml_content["implementation"]["script"]
-        assert "script.py" in yaml_content["implementation"]["script"]["path"]
-        assert "notebook" in yaml_content["implementation"]
-        assert "path" in yaml_content["implementation"]["notebook"]
-        assert "notebook.ipynb" in yaml_content["implementation"]["notebook"]["path"]
         assert "source" in yaml_content["implementation"]
         assert "archive" in yaml_content["implementation"]["source"]
         assert "path" in yaml_content["implementation"]["source"]["archive"]
@@ -116,7 +110,7 @@ def test_jupyter_notebook() -> None:
         assert "notebook path" in yaml_content["implementation"]["source"]["archive"]
         assert "notebook.ipynb" in yaml_content["implementation"]["source"]["archive"]["notebook path"]
 
-        archive_path = Path(yaml_content["implementation"]["source"]["archive"]["path"])
+        archive_path = Path(working_dir_path) / Path(yaml_content["implementation"]["source"]["archive"]["path"])
         assert archive_path.exists()
 
         with ZipFile(archive_path) as zip_file:

--- a/python/test/test_integration.py
+++ b/python/test/test_integration.py
@@ -58,7 +58,7 @@ def test_python_script() -> None:
         assert "script path" in yaml_content["implementation"]["source"]["archive"]
         assert "example.py" in yaml_content["implementation"]["source"]["archive"]["script path"]
 
-        archive_path = Path(working_dir_path) / Path(yaml_content["implementation"]["source"]["archive"]["path"])
+        archive_path = working_dir_path / Path(yaml_content["implementation"]["source"]["archive"]["path"])
         assert archive_path.exists()
 
         with ZipFile(archive_path) as zip_file:
@@ -110,7 +110,7 @@ def test_jupyter_notebook() -> None:
         assert "notebook path" in yaml_content["implementation"]["source"]["archive"]
         assert "notebook.ipynb" in yaml_content["implementation"]["source"]["archive"]["notebook path"]
 
-        archive_path = Path(working_dir_path) / Path(yaml_content["implementation"]["source"]["archive"]["path"])
+        archive_path = working_dir_path / Path(yaml_content["implementation"]["source"]["archive"]["path"])
         assert archive_path.exists()
 
         with ZipFile(archive_path) as zip_file:

--- a/python/tirex_tracker/archive_utils.py
+++ b/python/tirex_tracker/archive_utils.py
@@ -55,12 +55,24 @@ def _create_notebook_zip_archive(
     with redirect_stdout(None):
         ipython.run_line_magic("save", f"-f {script_file_path} 1-9999")
         ipython.run_line_magic("notebook", str(notebook_file_path))
-    return _create_zip_archive(
+    ret = _create_zip_archive(
         metadata_directory_path=metadata_directory_path,
         base_directory_path=metadata_directory_path,
         script_file_path=script_file_path,
         notebook_file_path=notebook_file_path,
     )
+
+    script_file_path.unlink()
+    notebook_file_path.unlink()
+
+    return ret
+
+
+def git_repo_or_none(script_file_path: Path) -> Optional[Repo]:
+    try:
+        return Repo(script_file_path, search_parent_directories=True)
+    except InvalidGitRepositoryError:
+        return None
 
 
 def create_git_zip_archive(
@@ -72,10 +84,8 @@ def create_git_zip_archive(
 
     :param directory_path_in_git_repository: A directory that is inside the Git repository that should be archived.
     """
-
-    try:
-        repo = Repo(script_file_path, search_parent_directories=True)
-    except InvalidGitRepositoryError:
+    repo = git_repo_or_none(script_file_path)
+    if repo is None:
         return None
 
     working_tree_dir = repo.working_tree_dir


### PR DESCRIPTION
The metadata properties for the python script and the notebook were wrong.
I.e., they pointed to the files in the code archive, not in the git repo and had absolute paths which is confusing when one just wants to know the name of the script in the repo.

This fixes the problem, in the code and in the unit tests.
