### PR TITLE
Fixed non-conformant YAML output

### DIFF
--- a/c/src/measure/stats/systemstats.cpp
+++ b/c/src/measure/stats/systemstats.cpp
@@ -22,6 +22,8 @@ namespace _fmt = fmt;
 #include <sstream>
 #include <tuple>
 
+#include "../utils/rangeutils.hpp"
+
 using namespace std::string_literals;
 
 using tirex::Stats;
@@ -417,17 +419,18 @@ Stats SystemStats::getInfo() {
 	auto info = getSysInfo();
 	auto cpuInfo = getCPUInfo();
 
-	std::string caches = "";
 	size_t cacheIdx = 1;
+	std::vector<std::string> entries;
 	for (auto& [unified, instruct, data] : cpuInfo.caches) {
 		if (unified)
-			caches += _fmt::format("\"l{}\": \"{} KiB\",", cacheIdx, unified / 1024);
+			entries.emplace_back(std::move(_fmt::format("\"l{}\": \"{} KiB\"", cacheIdx, unified / 1024)));
 		if (instruct)
-			caches += _fmt::format("\"l{}i\": \"{} KiB\",", cacheIdx, instruct / 1024);
+			entries.emplace_back(std::move(_fmt::format("\"l{}i\": \"{} KiB\"", cacheIdx, instruct / 1024)));
 		if (data)
-			caches += _fmt::format("\"l{}d\": \"{} KiB\",", cacheIdx, data / 1024);
+			entries.emplace_back(std::move(_fmt::format("\"l{}d\": \"{} KiB\"", cacheIdx, data / 1024)));
 		++cacheIdx;
 	}
+	std::string caches = "{"s + utils::join(entries, ',') + "}";
 
 	return makeFilteredStats(
 			enabled, std::pair{TIREX_OS_NAME, info.osname}, std::pair{TIREX_OS_KERNEL, info.kerneldesc},

--- a/jvm/library/src/main/kotlin/io/tira/tirex/tracker/Tracker.kt
+++ b/jvm/library/src/main/kotlin/io/tira/tirex/tracker/Tracker.kt
@@ -729,10 +729,6 @@ class TrackingHandle private constructor(
         val irMetadataYamlString = exportFilePath.readText()
             .removePrefix("ir_metadata.start\n") // Remove optional ir_metadata prefix line.
             .removeSuffix("ir_metadata.end\n") // Remove optional ir_metadata suffix line.
-            .replace(
-                Regex("""caches: (.*),"""),
-                """caches: {\1}"""
-            ) // FIXME: There's a bug in the YAML output format (https://github.com/tira-io/tirex-tracker/issues/42) that we work around here.
         val irMetadata: MutableMap<String, Any?> = yaml.load<MutableMap<String, Any?>>(irMetadataYamlString)
 
         // Add user-provided metadata.

--- a/python/tirex_tracker/__init__.py
+++ b/python/tirex_tracker/__init__.py
@@ -867,11 +867,6 @@ class TrackingHandle(ContextManager["TrackingHandle"], Mapping[Measure, ResultEn
         if buffer.endswith(b"ir_metadata.end\n"):
             buffer = buffer[: -len(b"ir_metadata.end\n")]
 
-        # FIXME: There's a bug in the YAML output format (https://github.com/tira-io/tirex-tracker/issues/42) that we work around here:
-        from re import sub
-
-        buffer = sub(rb"caches: (.*),", rb"caches: {\1}", buffer)
-
         with BytesIO(buffer) as yaml_file:
             yaml = YAML(typ="safe")
             tmp_ir_metadata = yaml.load(yaml_file)


### PR DESCRIPTION
This fixes #42 .
On my machine, the value for the caches is now `{"l1i": "352 KiB","l1d": "352 KiB","l2": "2816 KiB"}` for example.
Previously, the braces would have been missing and there would be a trailing comma.