### PR TITLE
Measurement at 0ms

### DIFF
--- a/c/src/measureapi.cpp
+++ b/c/src/measureapi.cpp
@@ -51,10 +51,10 @@ struct tirexMeasureHandle_st final {
 	static void monitorThread(tirexMeasureHandle_st* self) {
 		auto future = self->signal.get_future();
 		std::chrono::milliseconds intervall{self->pollIntervalMs};
-		while (future.wait_for(intervall) != std::future_status::ready) {
+		do {
 			for (auto& provider : self->providers)
 				provider->step();
-		}
+		} while (future.wait_for(intervall) != std::future_status::ready);
 	}
 };
 


### PR DESCRIPTION
With this PR, the measurement is started at 0ms. Previously, it was only started after the first `pollIntervall` has passed.