### PR TITLE
Removed Ubuntu 20.04 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
           - macos-13
@@ -31,15 +30,12 @@ jobs:
           - clang-19.1.0
           - msvc
         exclude:
-          - {runs-on: ubuntu-20.04, compiler: msvc}  # MSVC only supported windows
           - {runs-on: ubuntu-22.04, compiler: msvc}  # MSVC only supported windows
           - {runs-on: ubuntu-24.04, compiler: msvc}  # MSVC only supported windows
           - {runs-on: macos-13,     compiler: msvc}  # MSVC only supported windows
           - {runs-on: macos-14,     compiler: msvc}  # MSVC only supported windows
           - {runs-on: macos-15,     compiler: msvc}  # MSVC only supported windows
           - {runs-on: windows-2019, compiler: msvc}  # Internal error of the MSVC parser
-          - runs-on: ubuntu-20.04
-            compiler: gcc-14 # Cannot be installed.
           - runs-on: ubuntu-22.04
             compiler: gcc-14 # Cannot be installed.
           - runs-on: macos-13
@@ -72,7 +68,7 @@ jobs:
       - name: 🏗️ Build library
         run: cmake --build c/build/ --config Release --target tirex_tracker_full -j 16
       - name: 📤 Upload Linux library
-        if: matrix.runs-on == 'ubuntu-20.04' && matrix.compiler == 'clang-19.1.0'
+        if: matrix.runs-on == 'ubuntu-22.04' && matrix.compiler == 'clang-19.1.0'
         uses: actions/upload-artifact@v4
         with:
           name: c-library-linux
@@ -109,7 +105,6 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
           - macos-13
@@ -124,15 +119,12 @@ jobs:
           - clang-19.1.0
           - msvc
         exclude:
-          - {runs-on: ubuntu-20.04, compiler: msvc}  # MSVC only supported windows
           - {runs-on: ubuntu-22.04, compiler: msvc}  # MSVC only supported windows
           - {runs-on: ubuntu-24.04, compiler: msvc}  # MSVC only supported windows
           - {runs-on: macos-13,     compiler: msvc}  # MSVC only supported windows
           - {runs-on: macos-14,     compiler: msvc}  # MSVC only supported windows
           - {runs-on: macos-15,     compiler: msvc}  # MSVC only supported windows
           - {runs-on: windows-2019, compiler: msvc}  # Internal error of the MSVC parser
-          - runs-on: ubuntu-20.04
-            compiler: gcc-14 # Cannot be installed.
           - runs-on: ubuntu-22.04
             compiler: gcc-14 # Cannot be installed.
           - runs-on: macos-13
@@ -166,7 +158,7 @@ jobs:
       - name: 🏗️ Build CLI
         run: cmake --build c/build/ --config Release --target measure -j 16
       - name: 📤 Upload Linux CLI
-        if: matrix.runs-on == 'ubuntu-20.04' && matrix.compiler == 'clang-19.1.0'
+        if: matrix.runs-on == 'ubuntu-22.04' && matrix.compiler == 'clang-19.1.0'
         uses: actions/upload-artifact@v4
         with:
           name: c-cli-linux
@@ -185,7 +177,7 @@ jobs:
           path: c/build/examples/03_measure_command/Release/measure.exe
   c-build-debian-package:
     name: 🏗️ Build Debian package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: 📥 Check-out
         uses: actions/checkout@v4
@@ -267,7 +259,6 @@ jobs:
           - "17"
           - "21"
         runs-on:
-          - ubuntu-20.04
           - ubuntu-22.04
           # - ubuntu-24.04 # FIXME: Re-enable
           # - macos-13

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Code coverage](https://img.shields.io/codecov/c/github/tira-io/tirex-tracker?style=flat-square)](https://codecov.io/github/tira-io/tirex-tracker/)
 \
 [![Release](https://img.shields.io/github/v/tag/tira-io/tirex-tracker?style=flat-square&label=library)](https://github.com/tira-io/tirex-tracker/releases/)
-[![Ubuntu](https://img.shields.io/badge/ubuntu-20.04_%7C_22.04_%7C_24.04-blue?style=flat-square)](https://github.com/tira-io/tirex-tracker/releases/)
+[![Ubuntu](https://img.shields.io/badge/ubuntu-22.04_%7C_24.04-blue?style=flat-square)](https://github.com/tira-io/tirex-tracker/releases/)
 [![macOS](https://img.shields.io/badge/macos-13_%7C_14-blue?style=flat-square)](https://github.com/tira-io/tirex-tracker/releases/)
 [![Windows](https://img.shields.io/badge/windows-2019_%7C_2022_%7C_2025-blue?style=flat-square)](https://github.com/tira-io/tirex-tracker/releases/)
 \


### PR DESCRIPTION
This PR removes the `ubuntu-20.04` runner configuration since that one has been removed [since April 15](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/).

The Linux artifacts are now built on `ubuntu-22.04`. This also means that they will be linked against a new libc version and our Linux support is less broad now. We should probably reintroduce this support by running adding builds on older systems using containers (started in #51).