### PR TITLE
Report Energy Measurements to YAML

### DIFF
--- a/c/extensions/irtracker.cpp
+++ b/c/extensions/irtracker.cpp
@@ -215,7 +215,7 @@ static void writeResources(const ResultMap& results, std::ostream& stream) {
 	if (ResultMap::const_iterator it; (it = results.find(TIREX_CPU_USED_SYSTEM_PERCENT)) != results.end())
 		stream << "    used system: " << it->second << '\n';
 	if (ResultMap::const_iterator it; (it = results.find(TIREX_CPU_ENERGY_SYSTEM_JOULES)) != results.end())
-		stream << "    used energy: " << it->second << 'J \n';
+		stream << "    energy used system: " << it->second << " J\n";
 	//// GPU DATA
 	stream << "  gpu:\n";
 	if (ResultMap::const_iterator it; (it = results.find(TIREX_GPU_USED_PROCESS_PERCENT)) != results.end())
@@ -226,6 +226,8 @@ static void writeResources(const ResultMap& results, std::ostream& stream) {
 		stream << "    vram used process: " << it->second << '\n';
 	if (ResultMap::const_iterator it; (it = results.find(TIREX_GPU_VRAM_USED_SYSTEM_MB)) != results.end())
 		stream << "    vram used system: " << it->second << '\n';
+	if (ResultMap::const_iterator it; (it = results.find(TIREX_GPU_ENERGY_SYSTEM_JOULES)) != results.end())
+		stream << "    energy used system: " << it->second << " J\n";
 	//// RAM DATA
 	stream << "  ram:\n";
 	if (ResultMap::const_iterator it; (it = results.find(TIREX_RAM_USED_PROCESS_KB)) != results.end())
@@ -233,7 +235,7 @@ static void writeResources(const ResultMap& results, std::ostream& stream) {
 	if (ResultMap::const_iterator it; (it = results.find(TIREX_RAM_USED_SYSTEM_MB)) != results.end())
 		stream << "    used system: " << it->second << '\n';
 	if (ResultMap::const_iterator it; (it = results.find(TIREX_RAM_ENERGY_SYSTEM_JOULES)) != results.end())
-		stream << "    used energy: " << it->second << 'J \n';
+		stream << "    energy used system: " << it->second << " J\n";
 }
 
 // Not static because internally the measurecommand calls this. Not pretty :(

--- a/c/extensions/irtracker.cpp
+++ b/c/extensions/irtracker.cpp
@@ -214,6 +214,8 @@ static void writeResources(const ResultMap& results, std::ostream& stream) {
 		stream << "    used process: " << it->second << '\n';
 	if (ResultMap::const_iterator it; (it = results.find(TIREX_CPU_USED_SYSTEM_PERCENT)) != results.end())
 		stream << "    used system: " << it->second << '\n';
+	if (ResultMap::const_iterator it; (it = results.find(TIREX_CPU_ENERGY_SYSTEM_JOULES)) != results.end())
+		stream << "    used energy: " << it->second << 'J \n';
 	//// GPU DATA
 	stream << "  gpu:\n";
 	if (ResultMap::const_iterator it; (it = results.find(TIREX_GPU_USED_PROCESS_PERCENT)) != results.end())
@@ -230,6 +232,8 @@ static void writeResources(const ResultMap& results, std::ostream& stream) {
 		stream << "    used process: " << it->second << '\n';
 	if (ResultMap::const_iterator it; (it = results.find(TIREX_RAM_USED_SYSTEM_MB)) != results.end())
 		stream << "    used system: " << it->second << '\n';
+	if (ResultMap::const_iterator it; (it = results.find(TIREX_RAM_ENERGY_SYSTEM_JOULES)) != results.end())
+		stream << "    used energy: " << it->second << 'J \n';
 }
 
 // Not static because internally the measurecommand calls this. Not pretty :(

--- a/c/src/measure/stats/energystats.cpp
+++ b/c/src/measure/stats/energystats.cpp
@@ -41,9 +41,11 @@ Stats EnergyStats::getStats() {
 	auto results = tracker.calculate_energy().energy;
 	for (auto& [device, result] : results)
 		tirex::log::debug("cppjoules", "[{}] {}", device, result);
+	// Divide by 1000'000 since CPPJoules reports micro Joule (uJ)
 	return makeFilteredStats(
-			enabled, std::pair{TIREX_CPU_ENERGY_SYSTEM_JOULES, std::to_string(getOrDefault(results, "core-0", 0))},
-			std::pair{TIREX_RAM_ENERGY_SYSTEM_JOULES, std::to_string(getOrDefault(results, "dram-0", 0))},
+			enabled,
+			std::pair{TIREX_CPU_ENERGY_SYSTEM_JOULES, std::to_string(getOrDefault(results, "core-0", 0) / 1000'000)},
+			std::pair{TIREX_RAM_ENERGY_SYSTEM_JOULES, std::to_string(getOrDefault(results, "dram-0", 0) / 1000'000)},
 			std::pair{TIREX_GPU_ENERGY_SYSTEM_JOULES, std::to_string(getOrDefault(results, "nvidia_gpu_0", 0))}
 	);
 }


### PR DESCRIPTION
Previously, energy measurements were internally stored in micro Joule instead of Joule and energy data was not reported to the YAML.