### PR TITLE
Disable broken GCC 14 on macOS 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
             compiler: clang-19.1.0 # setup-cpp fails to setup
           - runs-on: macos-15
             compiler: clang-19.1.0 # Known issue with clang (https://github.com/llvm/llvm-project/issues/109549)
+          - runs-on: macos-15
+            compiler: gcc-14 # Some stlib functions not available.
           - {runs-on: windows-2019, compiler: clang-19.1.0}  # Wrongly configured by the action TODO: reenable once fixed
           - {runs-on: windows-2022, compiler: clang-19.1.0}  # Wrongly configured by the action TODO: reenable once fixed
           - {runs-on: windows-2025, compiler: clang-19.1.0}  # Wrongly configured by the action TODO: reenable once fixed
@@ -139,6 +141,8 @@ jobs:
             compiler: clang-19.1.0 # setup-cpp fails to setup
           - runs-on: macos-15
             compiler: clang-19.1.0 # Known issue with clang (https://github.com/llvm/llvm-project/issues/109549)
+          - runs-on: macos-15
+            compiler: gcc-14 # Some stlib functions not available.
           - {runs-on: windows-2019, compiler: clang-19.1.0}  # Wrongly configured by the action TODO: reenable once fixed
           - {runs-on: windows-2022, compiler: clang-19.1.0}  # Wrongly configured by the action TODO: reenable once fixed
           - {runs-on: windows-2025, compiler: clang-19.1.0}  # Wrongly configured by the action TODO: reenable once fixed

--- a/.gitignore
+++ b/.gitignore
@@ -573,3 +573,4 @@ build
 .vscode
 __pycache__
 build
+.venv*/


### PR DESCRIPTION
This PR just disables the problematic matrix build. Note that macOS build is still possible with GCC 13.