### PR TITLE
Report Joules for GPU instead of millijoules

### DIFF
--- a/c/src/measure/stats/energystats.cpp
+++ b/c/src/measure/stats/energystats.cpp
@@ -46,6 +46,6 @@ Stats EnergyStats::getStats() {
 			enabled,
 			std::pair{TIREX_CPU_ENERGY_SYSTEM_JOULES, std::to_string(getOrDefault(results, "core-0", 0) / 1000'000)},
 			std::pair{TIREX_RAM_ENERGY_SYSTEM_JOULES, std::to_string(getOrDefault(results, "dram-0", 0) / 1000'000)},
-			std::pair{TIREX_GPU_ENERGY_SYSTEM_JOULES, std::to_string(getOrDefault(results, "nvidia_gpu_0", 0))}
+			std::pair{TIREX_GPU_ENERGY_SYSTEM_JOULES, std::to_string(getOrDefault(results, "nvidia_gpu_0", 0) / 1000)}
 	);
 }


### PR DESCRIPTION
There was a slight mistake that GPU energy was reported in millijoules.