### PR TITLE
Deprecate Python Git archive

### DIFF
--- a/python/tirex_tracker/archive_utils.py
+++ b/python/tirex_tracker/archive_utils.py
@@ -3,134 +3,61 @@ from __future__ import annotations
 from contextlib import redirect_stdout
 from pathlib import Path
 from traceback import extract_stack
-from typing import Iterable, NamedTuple, Optional
-from zipfile import ZIP_DEFLATED, ZipFile
+from typing import NamedTuple, Optional
 
-from git import IndexObject, InvalidGitRepositoryError, Repo
 from IPython import InteractiveShell, get_ipython
 
 
 class ZipPaths(NamedTuple):
     script_file_path: Path
     notebook_file_path: Optional[Path]
-    zip_file_path: Path
-    script_file_path_in_zip: Path
-    notebook_file_path_in_zip: Optional[Path]
-
-
-def _create_zip_archive(
-    metadata_directory_path: Path,
-    base_directory_path: Path,
-    script_file_path: Path,
-    notebook_file_path: Optional[Path],
-    other_paths: Iterable[Path] = tuple(),
-) -> ZipPaths:
-    all_paths = {
-        script_file_path,
-        *([notebook_file_path] if notebook_file_path else []),
-        *other_paths,
-    }
-    zip_file_path = metadata_directory_path / "code.zip"
-    with ZipFile(zip_file_path, "w", compression=ZIP_DEFLATED) as zip_file:
-        for path in all_paths:
-            relative_path = path.relative_to(base_directory_path)
-            zip_file.write(path, arcname=relative_path)
-    return ZipPaths(
-        script_file_path=script_file_path,
-        notebook_file_path=notebook_file_path,
-        zip_file_path=zip_file_path,
-        script_file_path_in_zip=script_file_path.relative_to(base_directory_path),
-        notebook_file_path_in_zip=(notebook_file_path.relative_to(base_directory_path) if notebook_file_path else None),
-    )
+    script_file_path_in_git_archive: Optional[Path]
+    notebook_file_path_in_git_archive: Optional[Path]
 
 
 def _create_notebook_zip_archive(
     metadata_directory_path: Path,
     ipython: InteractiveShell,
+    git_archive_path: Optional[Path],
 ) -> ZipPaths:
-    notebook_file_path = metadata_directory_path / "notebook.ipynb"
     script_file_path = metadata_directory_path / "script.py"
+    notebook_file_path = metadata_directory_path / "notebook.ipynb"
     with redirect_stdout(None):
         ipython.run_line_magic("save", f"-f {script_file_path} 1-9999")
         ipython.run_line_magic("notebook", str(notebook_file_path))
-    ret = _create_zip_archive(
-        metadata_directory_path=metadata_directory_path,
-        base_directory_path=metadata_directory_path,
+
+    script_file_path_in_git_archive = Path("script.py")
+    notebook_file_path_in_git_archive = Path("notebook.ipynb")
+    # TODO: Add the notebook and script files to the Git archive.
+
+    return ZipPaths(
         script_file_path=script_file_path,
         notebook_file_path=notebook_file_path,
+        script_file_path_in_git_archive=script_file_path_in_git_archive,
+        notebook_file_path_in_git_archive=notebook_file_path_in_git_archive,
     )
-
-    script_file_path.unlink()
-    notebook_file_path.unlink()
-
-    return ret
-
-
-def git_repo_or_none(script_file_path: Path) -> Optional[Repo]:
-    try:
-        return Repo(script_file_path, search_parent_directories=True)
-    except InvalidGitRepositoryError:
-        return None
-
-
-def create_git_zip_archive(
-    metadata_directory_path: Path,
-    script_file_path: Path,
-) -> Optional[ZipPaths]:
-    """
-    Creates a ZIP archive containing all tracked files in a given Git repository.
-
-    :param directory_path_in_git_repository: A directory that is inside the Git repository that should be archived.
-    """
-    repo = git_repo_or_none(script_file_path)
-    if repo is None:
-        return None
-
-    with repo:
-        working_tree_dir = repo.working_tree_dir
-        if working_tree_dir is None:
-            return None
-        working_tree_dir_path = Path(working_tree_dir)
-
-        try:
-            repo_items = repo.commit().tree.traverse()
-        except ValueError:
-            return None
-
-        tracked_paths = (Path(item.abspath) for item in repo_items if isinstance(item, IndexObject))
-        tracked_paths = (path for path in tracked_paths if path.is_file())
-        tracked_paths = (path for path in tracked_paths if script_file_path.parent in path.parents)
-
-        return _create_zip_archive(
-            metadata_directory_path=metadata_directory_path,
-            base_directory_path=working_tree_dir_path,
-            script_file_path=script_file_path,
-            notebook_file_path=None,
-            other_paths=tracked_paths,
-        )
 
 
 def create_code_archive(
     metadata_directory_path: Path,
+    git_archive_path: Optional[Path],
+    git_root_path: Optional[Path],
 ) -> ZipPaths:
     ipython = get_ipython()
     if ipython is not None:
         return _create_notebook_zip_archive(
             metadata_directory_path=metadata_directory_path,
             ipython=ipython,
+            git_archive_path=git_archive_path,
         )
     else:
         script_file_path = Path(extract_stack()[0].filename).resolve()
 
-        paths = create_git_zip_archive(
-            metadata_directory_path=metadata_directory_path,
-            script_file_path=script_file_path,
-        )
-        if paths is not None:
-            return paths
-        return _create_zip_archive(
-            metadata_directory_path=metadata_directory_path,
-            base_directory_path=script_file_path.parent,
+        return ZipPaths(
             script_file_path=script_file_path,
             notebook_file_path=None,
+            script_file_path_in_git_archive=script_file_path.relative_to(git_root_path)
+            if git_root_path is not None
+            else None,
+            notebook_file_path_in_git_archive=None,
         )


### PR DESCRIPTION
As discussed in #137 and #67, this PR prepares the deprecation of Python-specific archiving.
Some obstacles, I encountered so far:
- We would need to know the Git root path to still be able to resolve relative paths, e.g., for `Measure.PYTHON_SCRIPT_FILE_PATH_IN_CODE_ARCHIVE`
- Immediately deleting the archive upon closing the result pointer will make it effectively inaccessible in Python, as the pointer is released after the measures have been read and parsed into Python objects in `TrackingHandle.stop()`
Let's discuss on how to best mitigate both issues before proceeding with the deprecation.