### PR TITLE
Add Windows & Linux ARM Runners and fix macOS upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
           # - ubuntu-24.04 # FIXME: Re-enable
           # - macos-14 # FIXME: JDK 8 cannot be installed.
           # - macos-15 # FIXME: JDK 8 cannot be installed.
-          - macos-26
+          # - macos-26 # FIXME: JDK 8 cannot be installed.
           - windows-2022
           # - windows-2025 # FIXME: Re-enable
         exclude:


### PR DESCRIPTION
Modifications to the CI:
- [x] Add windows-11-arm runner
- [x] Add apple-clang compiler for macos
- [x] Add Linux ARM runners
- [x] Remove macos-13 runner
- [x] Add macos-26 runner

Further:
- [ ] Create a followup issue to:
  - [ ] Upload Windows ARM and Linux ARM binaries as artifacts
  - [ ] Load these prebuilt binaries from Python and Java when running on Windows for ARM or Linux on ARM