### PR TITLE
Fixed ir_metadata export

### DIFF
--- a/c/examples/03_measure_command/formatters.cpp
+++ b/c/examples/03_measure_command/formatters.cpp
@@ -88,5 +88,5 @@ void tirex::jsonFormatter(std::ostream& stream, const tirexResult* info, const t
 extern tirexError writeIrMetadata(const tirexResult* info, const tirexResult* result, std::ostream& stream);
 
 void tirex::irmetadataFormatter(std::ostream& stream, const tirexResult* info, const tirexResult* result) noexcept {
-	writeIrMetadata(result, nullptr, stream);
+	writeIrMetadata(info, result, stream);
 }

--- a/c/extensions/irtracker.cpp
+++ b/c/extensions/irtracker.cpp
@@ -64,7 +64,7 @@ static const std::map<std::string, std::set<tirexMeasure>> measuresPerVersion{
 		  TIREX_GIT_UNCHECKED_FILES,
 		  TIREX_GIT_ROOT,
 		  TIREX_GIT_ARCHIVE_PATH,
-      TIREX_DEVCONTAINER_CONF_PATHS}}
+		  TIREX_DEVCONTAINER_CONF_PATHS}}
 };
 
 static std::function<bool(const tirexResultEntry&)> versionFilter(const std::string& version) {


### PR DESCRIPTION
`info` was not actually passed to the `ir_metadata` export.