### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - {host: ubuntu-latest, container: {image: "ubuntu:18.04", volumes: ["/tmp:/__e/node20"]}}
+          #- {host: ubuntu-latest, container: {image: "ubuntu:18.04", volumes: ["/tmp:/__e/node20"]}} # setup-cpp fails
           - {host: ubuntu-latest, container: {image: "ubuntu:20.04", volumes: ["/tmp:/__e/node20"]}}
           - {host: ubuntu-latest, container: {image: "ubuntu:25.04", volumes: ["/tmp:/__e/node20"]}}
           - {host: ubuntu-24.04-arm, container: {image: "node:20.18.1-bullseye" }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           - {platform: {host: macos-14},         compiler:  gcc-13}  # Known issue with gcc (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90835)
           - {platform: {host: macos-15},         compiler:  gcc-13}  # /opt/homebrew/Cellar/gcc@13/13.4.0/lib/gcc/13/gcc/aarch64-apple-darwin24/13/include-fixed/_stdio.h:78:10: fatal error: _bounds.h: No such file or directory
           - {platform: {host: macos-15},         compiler:  gcc-14}  # Known issue (https://github.com/munich-quantum-toolkit/core/issues/979, https://stackoverflow.com/questions/79641443/c-bounds-h-not-found-after-upgrading-to-gcc-15)
+          - {platform: {host: macos-26},         compiler:  gcc-13}  # Incompatible it seems
           - {platform: {host: macos-26},         compiler:  gcc-14}  # Incompatible it seems
           - {platform: {host: windows-2022},     compiler: llvm-19}  # libgit2 does not seem to support this
           - {platform: {host: windows-2025},     compiler: llvm-19}  # libgit2 does not seem to support this
@@ -182,6 +183,7 @@ jobs:
           - {platform: {host: macos-14},         compiler:  gcc-13}  # Known issue with gcc (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90835)
           - {platform: {host: macos-15},         compiler:  gcc-13}  # /opt/homebrew/Cellar/gcc@13/13.4.0/lib/gcc/13/gcc/aarch64-apple-darwin24/13/include-fixed/_stdio.h:78:10: fatal error: _bounds.h: No such file or directory
           - {platform: {host: macos-15},         compiler:  gcc-14}  # Known issue (https://github.com/munich-quantum-toolkit/core/issues/979, https://stackoverflow.com/questions/79641443/c-bounds-h-not-found-after-upgrading-to-gcc-15)
+          - {platform: {host: macos-26},         compiler:  gcc-13}  # Incompatible it seems
           - {platform: {host: macos-26},         compiler:  gcc-14}  # Incompatible it seems
           - {platform: {host: windows-2022},     compiler: llvm-19}  # libgit2 does not seem to support this
           - {platform: {host: windows-2025},     compiler: llvm-19}  # libgit2 does not seem to support this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           - {platform: {host: macos-14},         compiler:  gcc-13}  # Known issue with gcc (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90835)
           - {platform: {host: macos-15},         compiler:  gcc-13}  # /opt/homebrew/Cellar/gcc@13/13.4.0/lib/gcc/13/gcc/aarch64-apple-darwin24/13/include-fixed/_stdio.h:78:10: fatal error: _bounds.h: No such file or directory
           - {platform: {host: macos-15},         compiler:  gcc-14}  # Known issue (https://github.com/munich-quantum-toolkit/core/issues/979, https://stackoverflow.com/questions/79641443/c-bounds-h-not-found-after-upgrading-to-gcc-15)
+          - {platform: {host: macos-26},         compiler:  gcc-14}  # Incompatible it seems
           - {platform: {host: windows-2022},     compiler: llvm-19}  # libgit2 does not seem to support this
           - {platform: {host: windows-2025},     compiler: llvm-19}  # libgit2 does not seem to support this
         include:
@@ -181,6 +182,7 @@ jobs:
           - {platform: {host: macos-14},         compiler:  gcc-13}  # Known issue with gcc (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90835)
           - {platform: {host: macos-15},         compiler:  gcc-13}  # /opt/homebrew/Cellar/gcc@13/13.4.0/lib/gcc/13/gcc/aarch64-apple-darwin24/13/include-fixed/_stdio.h:78:10: fatal error: _bounds.h: No such file or directory
           - {platform: {host: macos-15},         compiler:  gcc-14}  # Known issue (https://github.com/munich-quantum-toolkit/core/issues/979, https://stackoverflow.com/questions/79641443/c-bounds-h-not-found-after-upgrading-to-gcc-15)
+          - {platform: {host: macos-26},         compiler:  gcc-14}  # Incompatible it seems
           - {platform: {host: windows-2022},     compiler: llvm-19}  # libgit2 does not seem to support this
           - {platform: {host: windows-2025},     compiler: llvm-19}  # libgit2 does not seem to support this
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - {host: ubuntu-latest, container: {image: "ubuntu:18.04", volumes: ["/tmp:/__e/node20"]}}
+          # - {host: ubuntu-latest, container: {image: "ubuntu:18.04", volumes: ["/tmp:/__e/node20"]}} # setup-cpp fails
           - {host: ubuntu-latest, container: {image: "ubuntu:20.04", volumes: ["/tmp:/__e/node20"]}}
           - {host: ubuntu-latest, container: {image: "ubuntu:25.04", volumes: ["/tmp:/__e/node20"]}}
           - {host: ubuntu-24.04-arm, container: {image: "node:20.18.1-bullseye" }}


### PR DESCRIPTION
setup-cpp (and other pipeline steps) now require NodeJS v24; on Ubuntu 18.04 we can at most install NodeJS v20. This PR disables the Ubuntu 18.04 runs for now. We can then find a way later to re-enable this. But this will mean a large rewrite of the CI.